### PR TITLE
Add the ability to run the release please action manually

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
I need to this to debug why its not working after transferring the repo over to the Node.js org.

I may be good in other failure cases and the job can be run multiple times as it should just update any existing PR for a release.